### PR TITLE
Hooks 2 - more hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,6 +195,42 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -659,6 +695,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-includes": {
@@ -3864,6 +3906,12 @@
         "array-includes": "^3.0.3"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -4148,6 +4196,12 @@
         "cli-cursor": "^2.0.0",
         "wrap-ansi": "^3.0.1"
       }
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.3",
@@ -4631,6 +4685,19 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -5052,6 +5119,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -5893,6 +5977,21 @@
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
+      }
+    },
+    "sinon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
       }
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-apollo": "^2.5.5",
     "react-apollo-hooks": "^0.4.5",
     "react-dom": "^16.8.6",
+    "sinon": "^7.3.2",
     "ts-node": "^8.2.0",
     "typescript": "^3.4.5"
   },

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,7 +98,12 @@ export default class MockClient extends ApolloClient<NormalizedCacheObject> {
   }
 
   mutate<T>(options: MutationOptions<T>): Promise<any> {
+    const mock = this.findMockFor(options);
+    if (options.update) {
+      const updateFn = options.update;
+      options.update = proxy => updateFn(proxy, mock);
+    }
     const result = super.mutate<T>(options);
-    return patchResponse(result, this.findMockFor(options));
+    return patchResponse(result, mock);
   }
 }

--- a/test/mutations_test.tsx
+++ b/test/mutations_test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Mutation } from 'react-apollo';
-// import { useMutation } from 'react-apollo-hooks';
+import { useMutation } from 'react-apollo-hooks';
 import gql from 'graphql-tag';
 import { mock, render, expect } from './helper';
 import { normalize } from '../src/utils';
@@ -36,27 +36,28 @@ const MutatorComponent = () => (
   </Mutation>
 );
 
-// const HookedMutatorComponent = () => {
-//   const [response, setResponse] = React.useState({ data: null, loading: false, error: null });
-//   const createItem = useMutation(mutation);
-//   const onClick = () => createItem({ variables: { name: 'new item' } })
-//     .then(setResponse as () => void)
-//     .catch(error => setResponse({ data: null, loading: false, error }));
+const HookedMutatorComponent = () => {
+  const [response, setResponse] = React.useState({ data: null, loading: false, error: null });
+  const createItem = useMutation(mutation);
+  const onClick = () =>
+    createItem({ variables: { name: 'new item' } })
+      .then(setResponse as () => void)
+      .catch(error => setResponse({ data: null, loading: false, error }));
 
-//   const { data, loading, error } = response;
+  const { data, loading, error } = response;
 
-//   if (loading) {
-//     return <div>Loading...</div>;
-//   }
-//   if (error) {
-//     return <div>{error.message}</div>;
-//   }
-//   if (data) {
-//     return <div id={data.createItem.id}>{data.createItem.name}</div>;
-//   }
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+  if (error) {
+    return <div>{error.message}</div>;
+  }
+  if (data) {
+    return <div id={data.createItem.id}>{data.createItem.name}</div>;
+  }
 
-//   return <button onClick={onClick}>click me</button>;
-// }
+  return <button onClick={onClick}>click me</button>;
+};
 
 describe('mutation queries', () => {
   describe('wrapped mutation component', () => {
@@ -121,65 +122,67 @@ describe('mutation queries', () => {
     });
   });
 
-  // describe('Hooked mutation component', () => {
-  //   it('allows to mock mutation queries', () => {
-  //     mock.expect(mutation).reply({
-  //       createItem: { id: 1, name: 'new item' },
-  //     });
+  describe('Hooked mutation component', () => {
+    it('allows to mock mutation queries', () => {
+      mock.expect(mutation).reply({
+        createItem: { id: 1, name: 'new item' },
+      });
 
-  //     const wrapper = render(<HookedMutatorComponent />);
-  //     expect(wrapper.html()).to.eql('<button>click me</button>');
+      const wrapper = render(<HookedMutatorComponent />);
+      expect(wrapper.html()).to.eql('<button>click me</button>');
 
-  //     wrapper.find('button').simulate('click');
-  //     expect(wrapper.html()).to.eql('<div id="1">new item</div>');
-  //   });
+      wrapper.find('button').simulate('click');
+      expect(wrapper.html()).to.eql('<div id="1">new item</div>');
+    });
 
-  //   it('allows to specify a failure response', () => {
-  //     mock.expect(mutation).fail('everything is terrible');
+    it('allows to specify a failure response', () => {
+      mock.expect(mutation).fail('everything is terrible');
 
-  //     const wrapper = render(<HookedMutatorComponent />);
-  //     wrapper.find('button').simulate('click');
+      const wrapper = render(<HookedMutatorComponent />);
+      wrapper.find('button').simulate('click');
 
-  //     expect(wrapper.html()).to.eql('<div>GraphQL error: everything is terrible</div>');
-  //   });
+      expect(wrapper.html()).to.eql('<div>GraphQL error: everything is terrible</div>');
+    });
 
-  //   it('allows to test the mutation loading state', () => {
-  //     mock
-  //       .expect(mutation)
-  //       .loading(true)
-  //       .reply({ createItem: {} });
+    it('allows to test the mutation loading state', async () => {
+      mock
+        .expect(mutation)
+        .loading(true)
+        .reply({ createItem: {} });
 
-  //     const wrapper = render(<HookedMutatorComponent />);
-  //     wrapper.find('button').simulate('click');
+      const wrapper = render(<HookedMutatorComponent />);
+      wrapper.find('button').simulate('click');
 
-  //     expect(wrapper.html()).to.eql('<div>Loading...</div>');
-  //   });
+      await Promise.resolve();
 
-  //   it('registers mutation calls in the history', () => {
-  //     mock.expect(mutation).reply({
-  //       createItem: { id: 1, name: 'new item' },
-  //     });
+      expect(wrapper.html()).to.eql('<div>Loading...</div>');
+    });
 
-  //     const wrapper = render(<HookedMutatorComponent />);
-  //     wrapper.find('button').simulate('click');
+    it('registers mutation calls in the history', () => {
+      mock.expect(mutation).reply({
+        createItem: { id: 1, name: 'new item' },
+      });
 
-  //     expect(mock.history.requests).to.eql([
-  //       {
-  //         mutation: normalize(mutation),
-  //         variables: { name: 'new item' },
-  //       },
-  //     ]);
-  //   });
+      const wrapper = render(<HookedMutatorComponent />);
+      wrapper.find('button').simulate('click');
 
-  //   it('allows to verify the exact variables that the mutation has been called with', () => {
-  //     const mut = mock.expect(mutation).reply({
-  //       createItem: { id: 1, name: 'new item' },
-  //     });
+      expect(mock.history.requests).to.eql([
+        {
+          mutation: normalize(mutation),
+          variables: { name: 'new item' },
+        },
+      ]);
+    });
 
-  //     const wrapper = render(<HookedMutatorComponent />);
-  //     wrapper.find('button').simulate('click');
+    it('allows to verify the exact variables that the mutation has been called with', () => {
+      const mut = mock.expect(mutation).reply({
+        createItem: { id: 1, name: 'new item' },
+      });
 
-  //     expect(mut.calls).to.eql([[{ name: 'new item' }]]);
-  //   });
-  // })
+      const wrapper = render(<HookedMutatorComponent />);
+      wrapper.find('button').simulate('click');
+
+      expect(mut.calls).to.eql([[{ name: 'new item' }]]);
+    });
+  });
 });

--- a/test/query_test.tsx
+++ b/test/query_test.tsx
@@ -14,6 +14,22 @@ const query = gql`
   }
 `;
 
+const query2 = gql`
+  query GetItems {
+    items {
+      id
+    }
+  }
+`;
+
+const query3 = gql`
+  query GetItems {
+    items {
+      name
+    }
+  }
+`;
+
 const ToDos = ({ items, error, loading }: any) => {
   if (loading) {
     return <div>Loading...</div>;
@@ -39,7 +55,7 @@ export const QueryComponent = () => (
   </Query>
 );
 
-export const HookedQueryComponent = () => {
+export const HookedQueryComponent = ({ query }: any) => {
   const { data, error, loading } = useQuery(query);
   const { items = [] } = data || {};
 
@@ -72,32 +88,36 @@ describe('query mocking', () => {
     });
   });
 
-  describe.only('hooked component', () => {
+  describe('hooked component', () => {
     it('handles mocked response', () => {
       console.log('case 1', { before: mock.expectations.mocks.map(m => m.response) });
       mock.expect(query).reply({
         items: [{ id: '1', name: 'one' }, { id: '2', name: 'two' }],
       });
-      console.log({ after: mock.expectations.mocks.map(m => m.response) });
+      console.log('case 1', { after: mock.expectations.mocks.map(m => m.response) });
 
-      expect(render(<HookedQueryComponent />).html()).to.eql('<ul><li>one</li><li>two</li></ul>');
+      expect(render(<HookedQueryComponent query={query} />).html()).to.eql(
+        '<ul><li>one</li><li>two</li></ul>'
+      );
     });
 
     it('allows to mock error states too', () => {
       console.log({ before: mock.expectations.mocks.map(m => m.response) });
 
-      mock.expect(query).fail('everything is terrible');
+      mock.expect(query2).fail('everything is terrible');
 
       console.log({ after: mock.expectations.mocks.map(m => m.response) });
 
-      expect(render(<HookedQueryComponent />).html()).to.eql(
+      expect(render(<HookedQueryComponent query={query2} />).html()).to.eql(
         '<div>GraphQL error: everything is terrible</div>'
       );
     });
 
     it('allows to simulate loading state too', () => {
-      mock.expect(query).loading(true);
-      expect(render(<HookedQueryComponent />).html()).to.eql('<div>Loading...</div>');
+      mock.expect(query3).loading(true);
+      expect(render(<HookedQueryComponent query={query3} />).html()).to.eql(
+        '<div>Loading...</div>'
+      );
     });
   });
 


### PR DESCRIPTION
- adds support for mutation update functions
- enable mutations tests
- "fix" query tests (use a different query for each test to avoid issues with react-apollo-hooks "caching")