### PR TITLE
add support for onCompleted

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,9 +18,14 @@ The query itself can be either a string or a `GraphQLQuery` object. You can
 either declare them anew in the tests (formatting doesn't matter) or re-use
 queries declared in your source code:
 
+Prior to `v2.0.0` query/mutation callbacks were not implemented and will not be
+fired when using `GraphqlMock` As of `v2.0.0` the `onCompleted` callback is
+implemented and will trigger automatically when using `GraphqlMock`. `onError`
+is yet to be implemented.
+
 ---
 
-`#expect(...).fail(...) used to make specific queries/mutations to fail. the
+`#expect(...).fail(...)` used to make specific queries/mutations to fail. the
 query/mutation/variables options are the same as above. The failure should be
 either a string, or an `ApolloError` instance.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@apollo/react-common": {
-      "version": "0.1.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-0.1.0-beta.10.tgz",
-      "integrity": "sha512-P4zrBn1BtPh5h0cCpIaf6FLWJ8CNFNUotGjOOXzzKYWcLsgrGRXBr4zcM0oW44qWoSWyfw/Y5iO2wuw4Tq2LPQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@apollo/react-common/-/react-common-3.1.4.tgz",
+      "integrity": "sha512-X5Kyro73bthWSCBJUC5XYQqMnG0dLWuDZmVkzog9dynovhfiVCV4kPSdgSIkqnb++cwCzOVuQ4rDKVwo2XRzQA==",
       "dev": true,
       "requires": {
         "ts-invariant": "^0.4.4",
@@ -15,12 +15,12 @@
       }
     },
     "@apollo/react-hooks": {
-      "version": "0.1.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-0.1.0-beta.12.tgz",
-      "integrity": "sha512-GQOm88syJ/i+cYNskjlmX2fXgHwA8kqM76tkGhFtlYk+IHMkyjm6iyxuih1jjw76Q6ERUwVKiX86KwW/Gw4giA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@apollo/react-hooks/-/react-hooks-3.1.2.tgz",
+      "integrity": "sha512-PV5u40E9iwfwM7u61r2P9PTjcGaM3zRwiwrJGDKOKaOn1Y9wTHhKOVEQa7YOsCWciSaMVK1slpKMvQbD2Ypqtw==",
       "dev": true,
       "requires": {
-        "@apollo/react-common": "^0.1.0-beta.10",
+        "@apollo/react-common": "^3.1.2",
         "@wry/equality": "^0.1.9",
         "ts-invariant": "^0.4.4",
         "tslib": "^1.10.0"
@@ -176,6 +176,41 @@
       "requires": {
         "any-observable": "^0.3.0"
       }
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.1.7",
@@ -2885,6 +2920,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
+      "dev": true
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -3151,6 +3192,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isequal": {
@@ -3476,6 +3523,19 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -3781,6 +3841,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -4323,6 +4400,43 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "graphql-tools": "^4.0.5"
   },
   "devDependencies": {
-    "@apollo/react-common": "0.1.0-beta.10",
-    "@apollo/react-hooks": "0.1.0-beta.12",
+    "@apollo/react-common": "^3.1.4",
+    "@apollo/react-hooks": "^3.1.2",
     "@types/chai": "^4.1.7",
     "@types/graphql": "^14.2.3",
     "@types/jsdom": "^12.2.4",
@@ -57,6 +57,7 @@
     "react-apollo": "^2.5.8",
     "react-apollo-hooks": "^0.5.0",
     "react-dom": "^16.8.6",
+    "sinon": "^10.0.0",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import Expectations from './expectations';
 import History from './history';
 import Mock from './mock';
 import Config from './config';
+import { isCompleted } from './utils';
 
 export * from './utils';
 export { Request } from './history';
@@ -26,7 +27,7 @@ export default class GraphQLMock {
     const { schema, mocks, resolvers } = this.args;
     const client = new MockClient(schema, mocks, resolvers);
 
-    client.notify(({ query, mutation, variables }: any) => {
+    client.notify(({ query, mutation, variables, onCompleted }: any) => {
       this.history.register({ query, mutation, variables });
 
       const mockResponse = this.expectations.findMockResponseFor(this.history.lastRequest);
@@ -39,6 +40,8 @@ export default class GraphQLMock {
 
         throw new Error(`Unexpected GraphQL request:\n${request.query || request.mutation}${vars}`);
       }
+
+      if (isCompleted(mockResponse) && onCompleted) onCompleted(mockResponse.data);
 
       return mockResponse;
     });

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -9,6 +9,13 @@ export interface Constructor {
   variables?: any;
 }
 
+export type MockResponse = {
+  data: any;
+  error?: ApolloError;
+  loading: boolean;
+  networkStatus: 'ready' | 'error';
+};
+
 export default class Mock {
   query: string;
   variables: any;
@@ -56,7 +63,7 @@ export default class Mock {
     return this;
   }
 
-  get response() {
+  get response(): MockResponse {
     const { data, error, loading } = this.results;
     const response: any = { data, loading, networkStatus: error ? 'error' : 'ready' };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as parser from 'graphql/language/parser';
 import * as printer from 'graphql/language/printer';
 import * as fastDeepEqual from 'fast-deep-equal';
+import { MockResponse } from './mock';
 
 export const { parse } = parser;
 export const stringify = printer.print;
@@ -8,6 +9,9 @@ export const normalize = (query: string | object) => {
   const queryObject = typeof query === 'string' ? parse(query) : query;
   return stringify(queryObject as any);
 };
+
+export const isCompleted = (response: MockResponse): boolean =>
+  response && !response.loading && response.networkStatus === 'ready';
 
 // TODO: make a more serious implementation of this
 export const fillIn = (query: string, variables: any = {}) => {

--- a/test/index_test.tsx
+++ b/test/index_test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ApolloClient } from 'apollo-client';
 import { mock, render, expect } from './helper';
-import { QueryComponent } from './query_test';
+import { QueryComponent, query } from './query_test';
 import History from '../src/history';
 
 describe('GraphqlMock', () => {
@@ -11,6 +11,16 @@ describe('GraphqlMock', () => {
 
   it('provides access to the history object', () => {
     expect(mock.history).to.be.instanceOf(History);
+  });
+
+  it('resolves when query is mocked correctly', () => {
+    mock.expect(query).reply({
+      items: [{ id: '1', name: 'one' }, { id: '2', name: 'two' }],
+    });
+
+    const wrapper = render(<QueryComponent />);
+
+    expect(wrapper.html()).to.eql('<ul><li>one</li><li>two</li></ul>');
   });
 
   it('explodes when query does not have an appropriate mock', () => {

--- a/test/query_test.tsx
+++ b/test/query_test.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import { Query } from 'react-apollo';
+import * as sinon from 'sinon';
 import { useQuery } from '@apollo/react-hooks';
 import { useQuery as rahUseQuery } from 'react-apollo-hooks';
 import gql from 'graphql-tag';
 import { mock, render, expect } from './helper';
 import { normalize } from '../src/utils';
 
-const query = gql`
+const sandbox = sinon.createSandbox();
+
+export const query = gql`
   query GetItems {
     items {
       id
@@ -54,7 +57,16 @@ export const HookedQueryComponent = () => {
   return <ToDos items={items} error={error} loading={loading} />;
 };
 
+export const CompleteCallbackComponent = ({ onCompleted }: any) => {
+  const { data, error, loading } = useQuery(query, { onCompleted });
+  const { items = [] } = data || {};
+
+  return <ToDos items={items} error={error} loading={loading} />;
+};
+
 describe('query mocking', () => {
+  afterEach(() => sandbox.restore());
+
   describe('Wrapped component', () => {
     it('handles mocked response', () => {
       mock.expect(query).reply({
@@ -123,6 +135,45 @@ describe('query mocking', () => {
     it('allows to simulate loading state too', () => {
       mock.expect(query).loading(true);
       expect(render(<HookedQueryComponent />).html()).to.eql('<div>Loading...</div>');
+    });
+  });
+
+  describe('onCompleted callback', () => {
+    it('triggers on success', () => {
+      const response = { items: [{ id: '1', name: 'one' }, { id: '2', name: 'two' }] };
+      mock.expect(query).reply(response);
+
+      const spy = sandbox.spy();
+
+      expect(render(<CompleteCallbackComponent onCompleted={spy} />).html()).to.eql(
+        '<ul><li>one</li><li>two</li></ul>'
+      );
+
+      expect(spy.firstCall.args[0]).to.eql(response);
+    });
+
+    it('does not trigger on failure', () => {
+      mock.expect(query).fail('everything is terrible');
+
+      const spy = sandbox.spy();
+
+      expect(render(<CompleteCallbackComponent onCompleted={spy} />).html()).to.eql(
+        '<div>GraphQL error: everything is terrible</div>'
+      );
+
+      expect(spy.callCount).to.equal(0);
+    });
+
+    it('does not trigger cwhen loading', () => {
+      mock.expect(query).loading(true);
+
+      const spy = sandbox.spy();
+
+      expect(render(<CompleteCallbackComponent onCompleted={spy} />).html()).to.eql(
+        '<div>Loading...</div>'
+      );
+
+      expect(spy.callCount).to.equal(0);
     });
   });
 


### PR DESCRIPTION
This PR adds support for triggering the `onCompleted` callback when a query/mutation finishes executing.

It is probably best to publish this as a breaking change, because if someone triggers any further GQL queries/mutations inside an onCompleted callback, this will now need additional mocking.